### PR TITLE
Don't declare _environ on Windows

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -42,11 +42,11 @@ setenv(const char* name, const char* value, int overwrite)
   return r;
 }
 #define environ _environ
+#else
+extern char **environ;
 #endif
 
 static char **origenviron;
-
-extern char **environ;
 
 mrb_value
 mrb_env_aget(mrb_state *mrb, mrb_value self)


### PR DESCRIPTION
Because `_environ` is declared in stdlib.h.
See: https://msdn.microsoft.com/en-us/library/stxk41x1.asp

`_environ` is declared with `dllimport` linker information. If we also
declare `_environ` as `extern char **environ`, icrosoft Visual C++
compiler generates C4273 (inconsistent DLL linkage) warning.
See about C4273: https://msdn.microsoft.com/en-us/library/35bhkfb6.aspx